### PR TITLE
Build a cfg of plain ebpf instructions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,6 +73,7 @@ DISASM_OBJECTS := \
     ${BUILDDIR}/asm_dis.o \
     ${BUILDDIR}/asm_ostream.o \
     ${BUILDDIR}/asm_marshal.o \
+    ${BUILDDIR}/asm_cfg.o \
     ${BUILDDIR}/prototypes.o
 
 $(BINDIR)/disassemble: ${DISASM_OBJECTS} 

--- a/src/asm.hpp
+++ b/src/asm.hpp
@@ -161,6 +161,8 @@ using Cfg = std::unordered_map<Label, BasicBlock>;
 
 Cfg build_cfg(const Program& prog);
 
+void print_stats(const Program& prog);
+
 // Helpers:
 
 struct InstructionVisitorPrototype {

--- a/src/asm.hpp
+++ b/src/asm.hpp
@@ -8,6 +8,8 @@
 
 #include <boost/lexical_cast.hpp>
 
+using Label = std::string;
+
 struct Imm {
     uint64_t v;
     Imm(int32_t v) : v{(uint32_t)v} { }
@@ -118,8 +120,10 @@ using Instruction = std::variant<
     LockAdd
 >;
 
+using pc_t = uint16_t;
+
 struct IndexedInstruction {
-    uint16_t pc;
+    pc_t pc;
     Instruction ins;
 };
 
@@ -136,12 +140,22 @@ std::ostream& operator<<(std::ostream& os, IndexedInstruction const& v);
 void print(Program& prog);
 
 
-inline std::function<auto(std::string)->int16_t> label_to_offset(uint16_t pc){
+inline std::function<auto(std::string)->int16_t> label_to_offset(pc_t pc){
     return [=](std::string label) {
         return boost::lexical_cast<int16_t>(label) - pc - 1;
     };
 }
 
+
+struct BasicBlock {
+    std::vector<Instruction> insts;
+    std::vector<Label> nextlist;
+    std::vector<Label> prevlist;
+};
+
+using Cfg = std::unordered_map<Label, BasicBlock>;
+
+Cfg build_cfg(const Program& prog);
 
 // Helpers:
 

--- a/src/asm.hpp
+++ b/src/asm.hpp
@@ -5,6 +5,7 @@
 #include <optional>
 #include <vector>
 #include <string>
+#include <unordered_map>
 
 #include <boost/lexical_cast.hpp>
 
@@ -137,15 +138,18 @@ constexpr int STACK_SIZE=512;
 std::variant<Program, std::string> parse(std::istream& is, size_t nbytes);
 
 std::ostream& operator<<(std::ostream& os, IndexedInstruction const& v);
-void print(Program& prog);
+void print(const Program& prog);
 
+
+inline pc_t label_to_pc(Label label) {
+    return boost::lexical_cast<int16_t>(label);
+}
 
 inline std::function<auto(std::string)->int16_t> label_to_offset(pc_t pc){
     return [=](std::string label) {
-        return boost::lexical_cast<int16_t>(label) - pc - 1;
+        return label_to_pc(label) - pc - 1;
     };
 }
-
 
 struct BasicBlock {
     std::vector<Instruction> insts;

--- a/src/asm.hpp
+++ b/src/asm.hpp
@@ -6,17 +6,17 @@
 #include <vector>
 #include <string>
 
+#include <boost/lexical_cast.hpp>
+
 struct Imm {
     uint64_t v;
     Imm(int32_t v) : v{(uint32_t)v} { }
     Imm(uint64_t v) : v{v} { }
 };
 
-enum Offset : int16_t {};
 enum Reg : int {};
 
 using Value = std::variant<Imm, Reg>;
-using Target = std::variant<Offset, Reg>;
 
 struct Bin {
     enum class Op {
@@ -60,7 +60,7 @@ struct Condition {
 
 struct Jmp {
     std::optional<Condition> cond;
-    int offset;
+    std::string target;
 };
 
 struct Call {
@@ -132,9 +132,16 @@ constexpr int STACK_SIZE=512;
 
 std::variant<Program, std::string> parse(std::istream& is, size_t nbytes);
 
-std::ostream& operator<<(std::ostream& os, Instruction const& v);
 std::ostream& operator<<(std::ostream& os, IndexedInstruction const& v);
 void print(Program& prog);
+
+
+inline std::function<auto(std::string)->int16_t> label_to_offset(uint16_t pc){
+    return [=](std::string label) {
+        return boost::lexical_cast<int16_t>(label) - pc - 1;
+    };
+}
+
 
 // Helpers:
 

--- a/src/asm_cfg.cpp
+++ b/src/asm_cfg.cpp
@@ -64,12 +64,36 @@ Cfg build_cfg(const Program& prog)
         link(cfg, label, get_fall(ins, pc));
         link(cfg, label, get_jump(ins, pc));
     }
-    for (auto const& [this_label, bb] : cfg) {
-        print(Program{bb.insts});
-        std::cout << "   ->      ";
-        for (auto s : bb.nextlist)
-            std::cout << s << ", ";
-        std::cout << "\n";
-    }
     return cfg;
+}
+
+void print_stats(const Program& prog) {
+    Cfg cfg = build_cfg(prog);
+    auto& insts = prog.code;
+    int count = 0;
+    int stores = 0;
+    int loads = 0;
+    int jumps = 0;
+    int joins = 0;
+    vector<int> reaching(insts.size());
+    for (auto const& [this_label, bb] : cfg) {
+        Instruction ins = bb.insts[0];
+        count++;
+        if (std::holds_alternative<Mem>(ins)) {
+            auto mem = std::get<Mem>(ins);
+            if (mem.isLoad())
+                loads++;
+            else
+                stores++;
+        }
+        if (bb.prevlist.size() > 1)
+            joins++;
+        if (bb.nextlist.size() > 1)
+            jumps++;
+    }
+    std::cout << "instructions:" << count << "\n";
+    std::cout << "loads:" << loads << "\n";
+    std::cout << "stores:" << stores << "\n";
+    std::cout << "jumps:" << jumps << "\n";
+    std::cout << "joins:" << joins << "\n";
 }

--- a/src/asm_cfg.cpp
+++ b/src/asm_cfg.cpp
@@ -1,0 +1,67 @@
+#include <inttypes.h>
+#include <assert.h>
+
+#include <vector>
+#include <string>
+#include <algorithm>
+#include <unordered_set>
+#include <unordered_map>
+#include <iostream>
+#include <optional>
+#include <iostream>
+
+#include "asm.hpp"
+
+using std::optional;
+using std::to_string;
+using std::string;
+using std::vector;
+
+static auto get_jump(Instruction ins, pc_t pc) -> optional<Label>
+{
+    if (std::holds_alternative<Jmp>(ins)) {
+        return std::get<Jmp>(ins).target;
+    }
+    return {};
+}
+
+static auto get_fall(Instruction ins, pc_t pc) -> optional<Label>
+{
+    if (std::holds_alternative<Bin>(ins)
+        && std::get<Bin>(ins).lddw)
+        return std::to_string(pc + 2);
+
+    if (std::holds_alternative<Exit>(ins))
+        return {};
+    if (std::holds_alternative<Undefined>(ins))
+        return {};
+
+    if (std::holds_alternative<Jmp>(ins)
+        && !std::get<Jmp>(ins).cond)
+            return {};
+
+    return std::to_string(pc + 1);
+}
+
+static void link(Cfg& cfg, Label from, optional<Label> to) {
+    if (to) {
+        cfg[from].nextlist.push_back(*to);
+        cfg[*to].prevlist.push_back(from);
+    }
+}
+
+Cfg build_cfg(const Program& prog)
+{
+    Cfg cfg;
+    for (pc_t pc = 0; pc < prog.code.size(); pc++) {
+        Instruction ins = prog.code[pc];
+        Label label = std::to_string(pc);
+
+        // create if not exists
+        cfg[label].insts = {ins};
+
+        link(cfg, label, get_jump(ins, pc));
+        link(cfg, label, get_fall(ins, pc));
+    }
+    return cfg;
+}

--- a/src/asm_cfg.cpp
+++ b/src/asm_cfg.cpp
@@ -56,12 +56,20 @@ Cfg build_cfg(const Program& prog)
     for (pc_t pc = 0; pc < prog.code.size(); pc++) {
         Instruction ins = prog.code[pc];
         Label label = std::to_string(pc);
-
+        if (std::holds_alternative<Undefined>(ins))
+            continue;
         // create if not exists
         cfg[label].insts = {ins};
 
-        link(cfg, label, get_jump(ins, pc));
         link(cfg, label, get_fall(ins, pc));
+        link(cfg, label, get_jump(ins, pc));
+    }
+    for (auto const& [this_label, bb] : cfg) {
+        print(Program{bb.insts});
+        std::cout << "   ->      ";
+        for (auto s : bb.nextlist)
+            std::cout << s << ", ";
+        std::cout << "\n";
     }
     return cfg;
 }

--- a/src/asm_marshal.cpp
+++ b/src/asm_marshal.cpp
@@ -1,6 +1,8 @@
 #include <variant>
 #include <iostream>
 #include <vector>
+#include <assert.h>
+
 
 #include "linux_ebpf.hpp"
 
@@ -76,6 +78,9 @@ private:
     }
 
 public:
+
+    std::function<auto(std::string)->int16_t> label_to_offset;
+
     vector<ebpf_inst> operator()(Undefined const& a) {
         assert(false);
     }
@@ -153,7 +158,7 @@ public:
             ebpf_inst res{
                 .opcode = static_cast<uint8_t>(EBPF_CLS_JMP | (op(b.cond->op) << 4)),
                 .dst = static_cast<uint8_t>(b.cond->left),
-                .offset = static_cast<int16_t>(b.offset),
+                .offset = label_to_offset(b.target),
             };
             visit(overloaded{
                 [&](Reg right) { 
@@ -169,7 +174,7 @@ public:
                     .opcode = EBPF_OP_JA,
                     .dst = 0,
                     .src = 0,
-                    .offset = static_cast<int16_t>(b.offset),
+                    .offset = label_to_offset(b.target),
                     .imm = 0
                 }
             };
@@ -228,15 +233,18 @@ public:
     }
 };
 
-vector<ebpf_inst> marshal(Instruction ins) {
-    return std::visit(MarshalVisitor{}, ins);
+vector<ebpf_inst> marshal(Instruction ins, uint16_t pc) {
+    return std::visit(MarshalVisitor{label_to_offset(pc)}, ins);
 }
 
 vector<ebpf_inst> marshal(vector<Instruction> insts) {
     vector<ebpf_inst> res;
+    uint16_t pc = 0;
     for (auto ins : insts) {
-        for (auto e: marshal(ins))
+        for (auto e: marshal(ins, pc)) {
+            pc++;
             res.push_back(e);
+        }
     }
     return res;
 }

--- a/src/asm_marshal.cpp
+++ b/src/asm_marshal.cpp
@@ -233,13 +233,13 @@ public:
     }
 };
 
-vector<ebpf_inst> marshal(Instruction ins, uint16_t pc) {
+vector<ebpf_inst> marshal(Instruction ins, pc_t pc) {
     return std::visit(MarshalVisitor{label_to_offset(pc)}, ins);
 }
 
 vector<ebpf_inst> marshal(vector<Instruction> insts) {
     vector<ebpf_inst> res;
-    uint16_t pc = 0;
+    pc_t pc = 0;
     for (auto ins : insts) {
         for (auto e: marshal(ins, pc)) {
             pc++;

--- a/src/asm_ostream.cpp
+++ b/src/asm_ostream.cpp
@@ -155,10 +155,10 @@ std::ostream& operator<< (std::ostream& os, IndexedInstruction const& v) {
     return os;
 }
 
-void print(Program& prog) {
+void print(const Program& prog) {
     pc_t pc = 0;
     for (auto ins : prog.code) {
-        pc++;
         std::cout << "    " << pc << " :        " << IndexedInstruction{pc, ins} << "\n";
+        pc++;
     }
 }

--- a/src/asm_ostream.cpp
+++ b/src/asm_ostream.cpp
@@ -146,7 +146,7 @@ struct InstructionVisitor {
     }
 };
 
-void print(std::ostream& os, Instruction const& v, uint16_t pc) {
+void print(std::ostream& os, Instruction const& v, pc_t pc) {
     std::visit(InstructionVisitor{os, label_to_offset(pc)}, v);
 }
 
@@ -156,7 +156,7 @@ std::ostream& operator<< (std::ostream& os, IndexedInstruction const& v) {
 }
 
 void print(Program& prog) {
-    uint16_t pc = 0;
+    pc_t pc = 0;
     for (auto ins : prog.code) {
         pc++;
         std::cout << "    " << pc << " :        " << IndexedInstruction{pc, ins} << "\n";

--- a/src/asm_ostream.cpp
+++ b/src/asm_ostream.cpp
@@ -48,8 +48,7 @@ static const char* size(Width w) {
 
 struct InstructionVisitor {
     std::ostream& os_;
-
-    InstructionVisitor(std::ostream& os) : os_{os} {}
+    std::function<auto(std::string)->int16_t> label_to_offset;
 
     void operator()(Undefined const& a) {
         os_ << "Undefined{" << a.opcode << "}";
@@ -93,7 +92,10 @@ struct InstructionVisitor {
             std::visit(*this, b.cond->right);
             os_ << " ";
         }
-        os_ << "goto +" << b.offset;
+        os_ << "goto ";
+        auto target = label_to_offset(b.target);
+        if (target > 0) os_ << "+";
+        os_ << target;
     }
 
     void operator()(Packet const& b) {
@@ -139,29 +141,24 @@ struct InstructionVisitor {
         else
             os_ << (int32_t)imm.v;
     }
-    void operator()(Offset off) {
-        os_ << static_cast<int16_t>(off);
-    }
     void operator()(Reg reg) {
         os_ << "r" << reg;
     }
 };
 
-std::ostream& operator<< (std::ostream& os, Instruction const& v) {
-    std::visit(InstructionVisitor{os}, v);
-    os << "";
-    return os;
+void print(std::ostream& os, Instruction const& v, uint16_t pc) {
+    std::visit(InstructionVisitor{os, label_to_offset(pc)}, v);
 }
 
 std::ostream& operator<< (std::ostream& os, IndexedInstruction const& v) {
-    os << "    " << v.pc << " :        " << v.ins;
+    print(os, v.ins, v.pc);
     return os;
 }
 
 void print(Program& prog) {
-    int pc = 0;
+    uint16_t pc = 0;
     for (auto ins : prog.code) {
         pc++;
-        std::cout << "    " << pc << " :        " << ins << "\n";
+        std::cout << "    " << pc << " :        " << IndexedInstruction{pc, ins} << "\n";
     }
 }

--- a/src/cfg.cpp
+++ b/src/cfg.cpp
@@ -19,9 +19,6 @@ using std::to_string;
 using std::string;
 using std::vector;
 
-
-using pc_t = uint16_t;
-
 static auto get_jump(Instruction ins, pc_t pc) -> optional<pc_t>
 {
     if (std::holds_alternative<Jmp>(ins)) {

--- a/src/cfg.cpp
+++ b/src/cfg.cpp
@@ -25,7 +25,7 @@ using pc_t = uint16_t;
 static auto get_jump(Instruction ins, pc_t pc) -> optional<pc_t>
 {
     if (std::holds_alternative<Jmp>(ins)) {
-        return pc + 1 + std::get<Jmp>(ins).offset;
+        return boost::lexical_cast<int>(std::get<Jmp>(ins).target);
     }
     return {};
 }

--- a/src/crab_cfg.cpp
+++ b/src/crab_cfg.cpp
@@ -9,8 +9,8 @@
 #include <optional>
 
 #include "common.hpp"
-#include "constraints.hpp"
-#include "cfg.hpp"
+#include "crab_constraints.hpp"
+#include "crab_cfg.hpp"
 #include "verifier.hpp"
 #include "asm.hpp"
 
@@ -18,30 +18,6 @@ using std::optional;
 using std::to_string;
 using std::string;
 using std::vector;
-
-static auto get_jump(Instruction ins, pc_t pc) -> optional<pc_t>
-{
-    if (std::holds_alternative<Jmp>(ins)) {
-        return label_to_pc(std::get<Jmp>(ins).target);
-    }
-    return {};
-}
-
-static auto get_fall(Instruction ins, pc_t pc) -> optional<pc_t>
-{
-    if (std::holds_alternative<Bin>(ins)
-        && std::get<Bin>(ins).lddw) {
-        return pc + 2;
-    }
-    if (std::holds_alternative<Exit>(ins)) {
-        return {};
-    }
-    if (std::holds_alternative<Jmp>(ins)) {
-        if (!std::get<Jmp>(ins).cond)
-            return {};
-    }
-    return pc + 1;
-}
 
 static auto build_jump(cfg_t& cfg, pc_t pc, Label target, bool taken) -> basic_block_t&
 {
@@ -55,69 +31,6 @@ static auto build_jump(cfg_t& cfg, pc_t pc, Label target, bool taken) -> basic_b
 static void link(cfg_t& cfg, pc_t pc, Label target)
 {
     cfg.get_node(exit_label(pc)) >> cfg.insert(target);
-}
-
-bool check_raw_reachability(const Program& prog)
-{
-    auto& insts = prog.code;
-    std::unordered_set<pc_t> unreachables;
-    for (pc_t i=1; i < insts.size(); i++)
-        unreachables.insert(i);
-
-    for (pc_t pc = 0; pc < insts.size(); pc++) {
-        Instruction ins = insts[pc];
-        optional<pc_t> jump_target = get_jump(ins, pc);
-        optional<pc_t> fall_target = get_fall(ins, pc);
-        if (jump_target) {
-            unreachables.erase(*jump_target);
-        }
-        
-        if (fall_target) {
-            unreachables.erase(*fall_target);
-            if (*fall_target == pc + 2)
-                unreachables.erase(++pc);
-        }
-    }
-    return unreachables.size() == 0;
-}
-
-void print_stats(const Program& prog) {
-    auto& insts = prog.code;
-    int count = 0;
-    int stores = 0;
-    int loads = 0;
-    int jumps = 0;
-    vector<int> reaching(insts.size());
-    for (pc_t pc = 0; pc < insts.size(); pc++) {
-        Instruction ins = insts[pc];
-        count++;
-        if (std::holds_alternative<Mem>(ins)) {
-            auto mem = std::get<Mem>(ins);
-            if (mem.isLoad())
-                loads++;
-            else
-                stores++;
-        }
-        optional<pc_t> jump_target = get_jump(ins, pc);
-        optional<pc_t> fall_target = get_fall(ins, pc);
-        if (jump_target) {
-            reaching[*jump_target]++;
-            jumps++;
-        }
-        if (fall_target) {
-            reaching[*fall_target]++;
-            pc = *fall_target - 1;
-        }
-    }
-    int joins = 0;
-    for (int n : reaching)
-        if (n > 1) joins++;
-
-    std::cout << "instructions:" << count << "\n";
-    std::cout << "loads:" << loads << "\n";
-    std::cout << "stores:" << stores << "\n";
-    std::cout << "jumps:" << jumps << "\n";
-    std::cout << "joins:" << joins << "\n";
 }
 
 void build_cfg(cfg_t& cfg, variable_factory_t& vfac, const Program& prog, ebpf_prog_type prog_type)

--- a/src/crab_cfg.hpp
+++ b/src/crab_cfg.hpp
@@ -47,8 +47,4 @@ inline basic_block_t& add_child(cfg_t& cfg, basic_block_t& block, std::string su
     return add_common_child(cfg, block, {block.label()}, suffix);
 }
 
-bool check_raw_reachability(const Program& prog);
-
 void build_cfg(cfg_t& cfg, variable_factory_t& vfac, const Program& prog, ebpf_prog_type prog_type);
-
-void print_stats(const Program& prog);

--- a/src/crab_constraints.cpp
+++ b/src/crab_constraints.cpp
@@ -4,7 +4,7 @@
 #include <type_traits>
 
 #include "common.hpp"
-#include "constraints.hpp"
+#include "crab_constraints.hpp"
 #include "prototypes.hpp"
 #include "type_descriptors.hpp"
 

--- a/src/crab_constraints.hpp
+++ b/src/crab_constraints.hpp
@@ -3,7 +3,7 @@
 #include <memory>
 
 #include "common.hpp"
-#include "cfg.hpp"
+#include "crab_cfg.hpp"
 
 #include "asm.hpp"
 

--- a/src/disassemble.cpp
+++ b/src/disassemble.cpp
@@ -25,7 +25,10 @@ int main(int argc, char **argv)
         return 65;
     }
     return std::visit(overloaded {
-        [](Program prog) { print(prog); return 0; },
+        [](Program prog) { print(prog); 
+            std::cout << "\n";
+            build_cfg(prog);
+            return 0; },
         [](string errmsg) { 
             std::cout << "Bad file: " << errmsg << "\n";
             return 1;


### PR DESCRIPTION
Resolve #38
Jump target is now a string label. This is dubious, but is needed to ease the writing of an assembler.